### PR TITLE
Update bootkali_init

### DIFF
--- a/assets/scripts/bootkali_init
+++ b/assets/scripts/bootkali_init
@@ -186,6 +186,12 @@ if ! $busybox mountpoint -q $mnt/dev; then
 
 	$busybox mount -o bind /dev $mnt/dev
 	$busybox mount -t devpts devpts $mnt/dev/pts
+	
+	if [ ! -d $mnt/dev/shm ]; then
+	    mkdir -p $mnt/dev/shm
+	fi
+	
+	$busybox mount -t tmpfs tmpfs $mnt/dev/shm
 	$busybox mount -t proc proc $mnt/proc
 	$busybox mount -t sysfs sysfs $mnt/sys
 

--- a/assets/scripts/bootkali_init
+++ b/assets/scripts/bootkali_init
@@ -61,6 +61,10 @@ if [ ! -d "$mnt/sys" ]; then
     mkdir -p $mnt/sys
 fi
 
+if [ ! -d $mnt/dev/shm ]; then
+    mkdir -p $mnt/dev/shm
+fi
+	
 if [ ! -d "$mnt/usr" ]; then
     echo "Missing a required folder. Something isn't right"
     exit 1
@@ -186,11 +190,6 @@ if ! $busybox mountpoint -q $mnt/dev; then
 
 	$busybox mount -o bind /dev $mnt/dev
 	$busybox mount -t devpts devpts $mnt/dev/pts
-	
-	if [ ! -d $mnt/dev/shm ]; then
-	    mkdir -p $mnt/dev/shm
-	fi
-	
 	$busybox mount -t tmpfs tmpfs $mnt/dev/shm
 	$busybox mount -t proc proc $mnt/proc
 	$busybox mount -t sysfs sysfs $mnt/sys


### PR DESCRIPTION
Add support for creation of /dev/shm for programs that utilize shared memory (Mozilla Firefox, Thunderbird, etc.) Fixes the `[GFX1-]: Failed to lock new back buffer` error for some apps.