### PR TITLE
Seperate Kali and Android enviroments

### DIFF
--- a/assets/scripts/bootkali
+++ b/assets/scripts/bootkali
@@ -15,7 +15,7 @@ SCRIPT_PATH=$(readlink -f $0)
 # start-rev-met, start-rev-met-elevated-win[8-7]
 
 if [ $# -eq 0 ]; then
-	$busybox chroot $mnt /bin/bash -i
+	$busybox chroot $mnt /bin/bash -c "if [ ! -f $HOME/.hushlogin ]; then touch $HOME/.hushlogin; fi; /bin/login -f root
 else
 
 	#APACHE

--- a/assets/scripts/bootkali
+++ b/assets/scripts/bootkali
@@ -15,7 +15,7 @@ SCRIPT_PATH=$(readlink -f $0)
 # start-rev-met, start-rev-met-elevated-win[8-7]
 
 if [ $# -eq 0 ]; then
-	$busybox chroot $mnt /bin/bash -c "if [ ! -f $HOME/.hushlogin ]; then touch $HOME/.hushlogin; fi; /bin/login -f root
+	$busybox chroot $mnt /bin/bash -c "if [ ! -f $HOME/.hushlogin ]; then touch $HOME/.hushlogin; fi; /bin/login -f root"
 else
 
 	#APACHE

--- a/assets/scripts/bootkali_bash
+++ b/assets/scripts/bootkali_bash
@@ -4,4 +4,4 @@
 SCRIPT_PATH=$(readlink -f $0)
 . ${SCRIPT_PATH%/*}/bootkali_env
 
-$busybox chroot $mnt /bin/bash -i
+$busybox chroot $mnt /bin/bash -c "if [ ! -f $HOME/.hushlogin ]; then touch $HOME/.hushlogin; fi; /bin/login -f root"

--- a/assets/scripts/bootkali_login
+++ b/assets/scripts/bootkali_login
@@ -4,4 +4,4 @@
 SCRIPT_PATH=$(readlink -f $0)
 . ${SCRIPT_PATH%/*}/bootkali_env
 
-$busybox chroot $mnt /bin/login -f root
+$busybox chroot $mnt /bin/bash -c "if [ -f $HOME/.hushlogin ]; then rm $HOME/.hushlogin; fi; /bin/login -f root"


### PR DESCRIPTION
This patch replaces the use of /bin/bash with /bin/login to clear the enviroment variable table and seperate Kali and Android enviroments. This patch fixes:

- Enviroment collision
- Broken VNC Manager servers
- Invisible text in some terminal GUI applications